### PR TITLE
Add Scala 3 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.6, 2.12.14]
+        scala: [2.13.6, 2.12.14, 3.0.1]
         java: [adopt@1.8, adopt@1.11]
     runs-on: ${{ matrix.os }}
     steps:
@@ -116,6 +116,16 @@ jobs:
           name: target-${{ matrix.os }}-2.12.14-${{ matrix.java }}
 
       - name: Inflate target directories (2.12.14)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (3.0.1)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-3.0.1-${{ matrix.java }}
+
+      - name: Inflate target directories (3.0.1)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/ci-release.sbt
+++ b/ci-release.sbt
@@ -1,5 +1,9 @@
 ThisBuild / scalaVersion := Dependencies.Versions.scala213
-ThisBuild / crossScalaVersions := Seq(Dependencies.Versions.scala213, Dependencies.Versions.scala212)
+ThisBuild / crossScalaVersions := Seq(
+  Dependencies.Versions.scala213,
+  Dependencies.Versions.scala212,
+  Dependencies.Versions.scala3
+)
 ThisBuild / githubWorkflowTargetTags ++= Seq("v*")
 ThisBuild / githubWorkflowJavaVersions := Seq("adopt@1.8", "adopt@1.11")
 

--- a/modules/sttp-client3/src/test/scala/io/janstenpickle/trace4cats/sttp/client3/Instances.scala
+++ b/modules/sttp-client3/src/test/scala/io/janstenpickle/trace4cats/sttp/client3/Instances.scala
@@ -2,14 +2,11 @@ package io.janstenpickle.trace4cats.sttp.client3
 
 import cats.data.Kleisli
 import cats.effect.IO
-import cats.effect.unsafe.IORuntime
 import io.janstenpickle.trace4cats.Span
 import io.janstenpickle.trace4cats.base.context.Local
-import io.janstenpickle.trace4cats.sttp.common.TraceContext
+import io.janstenpickle.trace4cats.sttp.common.{CommonInstances, TraceContext}
 
-object Instances {
+object Instances extends CommonInstances {
   implicit val localSpan: Local[Kleisli[IO, TraceContext[IO], *], Span[IO]] =
     Local[Kleisli[IO, TraceContext[IO], *], TraceContext[IO]].focus(TraceContext.span[IO])
-
-  implicit val runtime: IORuntime = IORuntime.global
 }

--- a/modules/sttp-client3/src/test/scala/io/janstenpickle/trace4cats/sttp/client3/TracedSttpBackendCtxSpec.scala
+++ b/modules/sttp-client3/src/test/scala/io/janstenpickle/trace4cats/sttp/client3/TracedSttpBackendCtxSpec.scala
@@ -2,15 +2,14 @@ package io.janstenpickle.trace4cats.sttp.client3
 
 import cats.data.Kleisli
 import cats.effect.IO
-import cats.{~>, Id}
 import io.janstenpickle.trace4cats.ToHeaders
 import io.janstenpickle.trace4cats.sttp.client3.Instances._
 import io.janstenpickle.trace4cats.sttp.client3.syntax._
-import io.janstenpickle.trace4cats.sttp.common.TraceContext
+import io.janstenpickle.trace4cats.sttp.common.{RunIOToId, TraceContext}
 
 class TracedSttpBackendCtxSpec
     extends BaseSttpBackendTracerSpec[IO, Kleisli[IO, TraceContext[IO], *], TraceContext[IO]](
-      λ[IO ~> Id](_.unsafeRunSync()),
+      RunIOToId,
       TraceContext("bf2665b3-2201-466d-868d-8bd3ab151d79", _),
       _.liftTraceContext(spanLens = TraceContext.span[IO], headersGetter = TraceContext.headers[IO](ToHeaders.standard))
     )

--- a/modules/sttp-client3/src/test/scala/io/janstenpickle/trace4cats/sttp/client3/TracedSttpBackendSpec.scala
+++ b/modules/sttp-client3/src/test/scala/io/janstenpickle/trace4cats/sttp/client3/TracedSttpBackendSpec.scala
@@ -2,14 +2,9 @@ package io.janstenpickle.trace4cats.sttp.client3
 
 import cats.data.Kleisli
 import cats.effect.IO
-import cats.{~>, Id}
 import io.janstenpickle.trace4cats.Span
-import io.janstenpickle.trace4cats.sttp.client3.Instances._
 import io.janstenpickle.trace4cats.sttp.client3.syntax._
+import io.janstenpickle.trace4cats.sttp.common.RunIOToId
 
 class TracedSttpBackendSpec
-    extends BaseSttpBackendTracerSpec[IO, Kleisli[IO, Span[IO], *], Span[IO]](
-      λ[IO ~> Id](_.unsafeRunSync()),
-      identity,
-      _.liftTrace()
-    )
+    extends BaseSttpBackendTracerSpec[IO, Kleisli[IO, Span[IO], *], Span[IO]](RunIOToId, identity, _.liftTrace())

--- a/modules/sttp-common/src/test/scala/io/janstenpickle/trace4cats/sttp/common/CommonInstances.scala
+++ b/modules/sttp-common/src/test/scala/io/janstenpickle/trace4cats/sttp/common/CommonInstances.scala
@@ -1,0 +1,9 @@
+package io.janstenpickle.trace4cats.sttp.common
+
+import cats.effect.unsafe.IORuntime
+
+trait CommonInstances {
+  implicit val runtime: IORuntime = IORuntime.global
+}
+
+object CommonInstances extends CommonInstances

--- a/modules/sttp-common/src/test/scala/io/janstenpickle/trace4cats/sttp/common/RunIOToId.scala
+++ b/modules/sttp-common/src/test/scala/io/janstenpickle/trace4cats/sttp/common/RunIOToId.scala
@@ -1,0 +1,9 @@
+package io.janstenpickle.trace4cats.sttp.common
+
+import cats.{~>, Id}
+import cats.effect.IO
+import io.janstenpickle.trace4cats.sttp.common.CommonInstances._
+
+object RunIOToId extends (IO ~> Id) {
+  def apply[A](fa: IO[A]): Id[A] = fa.unsafeRunSync()
+}

--- a/modules/sttp-common/src/test/scala/io/janstenpickle/trace4cats/sttp/common/SttpHeadersConverterSpec.scala
+++ b/modules/sttp-common/src/test/scala/io/janstenpickle/trace4cats/sttp/common/SttpHeadersConverterSpec.scala
@@ -11,7 +11,7 @@ import sttp.model.{Header, Headers}
 class SttpHeadersConverterSpec extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks with ArbitraryInstances {
   behavior.of("SttpHeaders.converter")
 
-  it should "convert headers isomorphically" in forAll { traceHeaders: TraceHeaders =>
+  it should "convert headers isomorphically" in forAll { (traceHeaders: TraceHeaders) =>
     assert(Eq.eqv(traceHeaders, converter.from(converter.to(traceHeaders))))
   }
 

--- a/modules/sttp-tapir/src/test/scala/io/janstenpickle/trace4cats/sttp/tapir/Instances.scala
+++ b/modules/sttp-tapir/src/test/scala/io/janstenpickle/trace4cats/sttp/tapir/Instances.scala
@@ -2,14 +2,11 @@ package io.janstenpickle.trace4cats.sttp.tapir
 
 import cats.data.Kleisli
 import cats.effect.IO
-import cats.effect.unsafe.IORuntime
 import io.janstenpickle.trace4cats.Span
 import io.janstenpickle.trace4cats.base.context.Local
-import io.janstenpickle.trace4cats.sttp.common.TraceContext
+import io.janstenpickle.trace4cats.sttp.common.{CommonInstances, TraceContext}
 
-object Instances {
+object Instances extends CommonInstances {
   implicit val localSpan: Local[Kleisli[IO, TraceContext[IO], *], Span[IO]] =
     Local[Kleisli[IO, TraceContext[IO], *], TraceContext[IO]].focus(TraceContext.span[IO])
-
-  implicit val runtime: IORuntime = IORuntime.global
 }

--- a/modules/sttp-tapir/src/test/scala/io/janstenpickle/trace4cats/sttp/tapir/TracedServerEndpointCtxSpec.scala
+++ b/modules/sttp-tapir/src/test/scala/io/janstenpickle/trace4cats/sttp/tapir/TracedServerEndpointCtxSpec.scala
@@ -2,13 +2,12 @@ package io.janstenpickle.trace4cats.sttp.tapir
 
 import cats.data.Kleisli
 import cats.effect.IO
-import cats.{~>, Id}
-import io.janstenpickle.trace4cats.sttp.common.TraceContext
+import io.janstenpickle.trace4cats.sttp.common.{RunIOToId, TraceContext}
 import io.janstenpickle.trace4cats.sttp.tapir.Instances._
 
 class TracedServerEndpointCtxSpec
     extends BaseServerEndpointTracerSpec[IO](
-      λ[IO ~> Id](_.unsafeRunSync()),
+      RunIOToId,
       new Endpoints[IO, Kleisli[IO, TraceContext[IO], *]].tracedContextEndpoints(_),
       checkMkContextErrors = true
     )

--- a/modules/sttp-tapir/src/test/scala/io/janstenpickle/trace4cats/sttp/tapir/TracedServerEndpointSpec.scala
+++ b/modules/sttp-tapir/src/test/scala/io/janstenpickle/trace4cats/sttp/tapir/TracedServerEndpointSpec.scala
@@ -2,13 +2,12 @@ package io.janstenpickle.trace4cats.sttp.tapir
 
 import cats.data.Kleisli
 import cats.effect.IO
-import cats.{~>, Id}
 import io.janstenpickle.trace4cats.Span
-import io.janstenpickle.trace4cats.sttp.tapir.Instances._
+import io.janstenpickle.trace4cats.sttp.common.RunIOToId
 
 class TracedServerEndpointSpec
     extends BaseServerEndpointTracerSpec[IO](
-      λ[IO ~> Id](_.unsafeRunSync()),
+      RunIOToId,
       new Endpoints[IO, Kleisli[IO, Span[IO], *]].tracedEndpoints(_),
       checkMkContextErrors = false
     )

--- a/modules/sttp-tapir/src/test/scala/io/janstenpickle/trace4cats/sttp/tapir/model/ErrorInfo.scala
+++ b/modules/sttp-tapir/src/test/scala/io/janstenpickle/trace4cats/sttp/tapir/model/ErrorInfo.scala
@@ -1,6 +1,7 @@
 package io.janstenpickle.trace4cats.sttp.tapir.model
 
 import cats.Show
+import cats.syntax.show._
 import io.circe.generic.auto._
 import io.janstenpickle.trace4cats.base.optics.Getter
 import sttp.model.StatusCode
@@ -16,7 +17,12 @@ object ErrorInfo {
   case class Unknown(code: Int, msg: String) extends ErrorInfo
   case object NoContent extends ErrorInfo
 
-  implicit val show: Show[ErrorInfo] = cats.derived.semiauto.show
+  implicit val show: Show[ErrorInfo] = Show.show {
+    case NotFound(what) => show"NotFound(what = $what)"
+    case Unauthorized(realm) => show"Unauthorized(realm = $realm)"
+    case Unknown(code, msg) => show"Unknown(code = $code, msg = $msg)"
+    case NoContent => show"NoContent"
+  }
 
   val endpointOutput: EndpointOutput[ErrorInfo] =
     oneOf[ErrorInfo](

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
     val scala3 = "3.0.1"
 
     val trace4cats = "0.12.0-RC2+17-d73c7ff3"
-    val trace4catsHttp4s = "0.12.0-RC2+5-acd4b5b6"
+    val trace4catsHttp4s = "0.12.0-RC2+4-3d20c440"
 
     val http4s = "0.23.0-RC1"
     val logback = "1.2.5"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,6 +4,7 @@ object Dependencies {
   object Versions {
     val scala212 = "2.12.14"
     val scala213 = "2.13.6"
+    val scala3 = "3.0.1"
 
     val trace4cats = "0.12.0-RC2"
     val trace4catsHttp4s = "0.12.0-RC2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,8 +6,8 @@ object Dependencies {
     val scala213 = "2.13.6"
     val scala3 = "3.0.1"
 
-    val trace4cats = "0.12.0-RC2"
-    val trace4catsHttp4s = "0.12.0-RC2"
+    val trace4cats = "0.12.0-RC2+17-d73c7ff3"
+    val trace4catsHttp4s = "0.12.0-RC2+5-acd4b5b6"
 
     val http4s = "0.23.0-RC1"
     val logback = "1.2.5"


### PR DESCRIPTION
Add Scala 3, replace single `Show` instance derived via kittens with manual one. Needs a Scala 3-compatible build of trace4cats core and http4s components, see https://github.com/trace4cats/trace4cats/pull/587