### PR TITLE
Add response attribute extraction

### DIFF
--- a/modules/sttp-client3/src/main/scala/io/janstenpickle/trace4cats/sttp/client3/SttpBackendSyntax.scala
+++ b/modules/sttp-client3/src/main/scala/io/janstenpickle/trace4cats/sttp/client3/SttpBackendSyntax.scala
@@ -23,7 +23,7 @@ trait SttpBackendSyntax {
         Getter((toHeaders.fromContext _).compose(_.context)),
         spanNamer,
         dropHeadersWhen,
-        attributesFromResponse
+        responseAttributesGetter
       )
 
     def liftTraceContext[G[_], Ctx](
@@ -39,7 +39,7 @@ trait SttpBackendSyntax {
         headersGetter,
         spanNamer,
         dropHeadersWhen,
-        attributesFromResponse
+        responseAttributesGetter
       )
   }
 

--- a/modules/sttp-client3/src/main/scala/io/janstenpickle/trace4cats/sttp/client3/SttpBackendSyntax.scala
+++ b/modules/sttp-client3/src/main/scala/io/janstenpickle/trace4cats/sttp/client3/SttpBackendSyntax.scala
@@ -15,7 +15,7 @@ trait SttpBackendSyntax {
       toHeaders: ToHeaders = ToHeaders.standard,
       spanNamer: SttpSpanNamer = SttpSpanNamer.methodWithPath,
       dropHeadersWhen: String => Boolean = HeaderNames.isSensitive,
-      attributesFromResponse: Getter[Response[Unit], Map[String, AttributeValue]] = Getter(_ => Map.empty)
+      responseAttributesGetter: Getter[Response[_], Map[String, AttributeValue]] = Getter(_ => Map.empty)
     )(implicit P: Provide[F, G, Span[F]], F: MonadCancelThrow[F], G: Async[G]): SttpBackend[G, P] =
       new SttpBackendTracer[F, G, P, Span[F]](
         backend,
@@ -31,7 +31,7 @@ trait SttpBackendSyntax {
       headersGetter: Getter[Ctx, TraceHeaders],
       spanNamer: SttpSpanNamer = SttpSpanNamer.methodWithPath,
       dropHeadersWhen: String => Boolean = HeaderNames.isSensitive,
-      attributesFromResponse: Getter[Response[Unit], Map[String, AttributeValue]] = Getter(_ => Map.empty)
+      responseAttributesGetter: Getter[Response[_], Map[String, AttributeValue]] = Getter(_ => Map.empty)
     )(implicit P: Provide[F, G, Ctx], F: MonadCancelThrow[F], G: Async[G]): SttpBackend[G, P] =
       new SttpBackendTracer[F, G, P, Ctx](
         backend,

--- a/modules/sttp-client3/src/main/scala/io/janstenpickle/trace4cats/sttp/client3/SttpBackendSyntax.scala
+++ b/modules/sttp-client3/src/main/scala/io/janstenpickle/trace4cats/sttp/client3/SttpBackendSyntax.scala
@@ -3,30 +3,33 @@ package io.janstenpickle.trace4cats.sttp.client3
 import cats.effect.kernel.{Async, MonadCancelThrow}
 import io.janstenpickle.trace4cats.base.context.Provide
 import io.janstenpickle.trace4cats.base.optics.{Getter, Lens}
-import io.janstenpickle.trace4cats.model.TraceHeaders
+import io.janstenpickle.trace4cats.model.{AttributeValue, TraceHeaders}
 import io.janstenpickle.trace4cats.{Span, ToHeaders}
-import sttp.client3.SttpBackend
+import sttp.client3.{Response, SttpBackend}
 
 trait SttpBackendSyntax {
 
   implicit class TracedSttpBackendSyntax[F[_], +P](backend: SttpBackend[F, P]) {
     def liftTrace[G[_]](
       toHeaders: ToHeaders = ToHeaders.standard,
-      spanNamer: SttpSpanNamer = SttpSpanNamer.methodWithPath
+      spanNamer: SttpSpanNamer = SttpSpanNamer.methodWithPath,
+      attributesFromResponse: Getter[Response[Unit], Map[String, AttributeValue]] = Getter(_ => Map.empty)
     )(implicit P: Provide[F, G, Span[F]], F: MonadCancelThrow[F], G: Async[G]): SttpBackend[G, P] =
       new SttpBackendTracer[F, G, P, Span[F]](
         backend,
         Lens.id,
         Getter((toHeaders.fromContext _).compose(_.context)),
-        spanNamer
+        spanNamer,
+        attributesFromResponse
       )
 
     def liftTraceContext[G[_], Ctx](
       spanLens: Lens[Ctx, Span[F]],
       headersGetter: Getter[Ctx, TraceHeaders],
-      spanNamer: SttpSpanNamer = SttpSpanNamer.methodWithPath
+      spanNamer: SttpSpanNamer = SttpSpanNamer.methodWithPath,
+      attributesFromResponse: Getter[Response[Unit], Map[String, AttributeValue]] = Getter(_ => Map.empty)
     )(implicit P: Provide[F, G, Ctx], F: MonadCancelThrow[F], G: Async[G]): SttpBackend[G, P] =
-      new SttpBackendTracer[F, G, P, Ctx](backend, spanLens, headersGetter, spanNamer)
+      new SttpBackendTracer[F, G, P, Ctx](backend, spanLens, headersGetter, spanNamer, attributesFromResponse)
   }
 
 }

--- a/modules/sttp-client3/src/main/scala/io/janstenpickle/trace4cats/sttp/client3/SttpBackendTracer.scala
+++ b/modules/sttp-client3/src/main/scala/io/janstenpickle/trace4cats/sttp/client3/SttpBackendTracer.scala
@@ -52,7 +52,7 @@ class SttpBackendTracer[F[_], G[_], +P, Ctx](
             resp <- lower(ctxBackend.send(req))
             _ <- childSpan.setStatus(SttpStatusMapping.statusToSpanStatus(resp.statusText, resp.code))
             respHeaderAttrs = SttpHeaders.responseFields(Headers(resp.headers), dropHeadersWhen)
-            // attributesFromResponse could be expensive, so only call if the span is sampled
+            // responseAttributesGetter could be expensive, so only call if the span is sampled
             respExtraAttrs = if (isSampled) responseAttributesGetter.get(resp) else Map.empty
             _ <- childSpan.putAll(respHeaderAttrs ++ respExtraAttrs: _*)
           } yield resp


### PR DESCRIPTION
Supports extracting span attributes depending on the sttp response, for example to have HTTP status codes in traces.