### PR TITLE
Update tapir integration for M16

### DIFF
--- a/modules/sttp-tapir/src/main/scala/io/janstenpickle/trace4cats/sttp/tapir/package.scala
+++ b/modules/sttp-tapir/src/main/scala/io/janstenpickle/trace4cats/sttp/tapir/package.scala
@@ -5,7 +5,7 @@ import io.janstenpickle.trace4cats.model.SpanStatus
 import sttp.tapir.Endpoint
 
 package object tapir {
-  type TapirSpanNamer[I] = (Endpoint[I, _, _, _], I) => SpanName
+  type TapirSpanNamer[I] = (Endpoint[_, I, _, _, _], I) => SpanName
   type TapirInputSpanNamer[I] = I => SpanName
   type TapirStatusMapping[E] = E => SpanStatus
 }

--- a/modules/sttp-tapir/src/test/scala/io/janstenpickle/trace4cats/sttp/tapir/BaseServerEndpointTracerSpec.scala
+++ b/modules/sttp-tapir/src/test/scala/io/janstenpickle/trace4cats/sttp/tapir/BaseServerEndpointTracerSpec.scala
@@ -22,7 +22,7 @@ import scala.collection.immutable.Queue
 
 abstract class BaseServerEndpointTracerSpec[F[_]: Async](
   unsafeRunK: F ~> Id,
-  injectEndpoints: EntryPoint[F] => List[ServerEndpoint[_, _, _, Any, F]],
+  injectEndpoints: EntryPoint[F] => List[ServerEndpoint[Any, F]],
   checkMkContextErrors: Boolean
 ) extends AnyFlatSpec
     with ScalaCheckDrivenPropertyChecks

--- a/modules/sttp-tapir/src/test/scala/io/janstenpickle/trace4cats/sttp/tapir/model/ErrorInfo.scala
+++ b/modules/sttp-tapir/src/test/scala/io/janstenpickle/trace4cats/sttp/tapir/model/ErrorInfo.scala
@@ -26,10 +26,10 @@ object ErrorInfo {
 
   val endpointOutput: EndpointOutput[ErrorInfo] =
     oneOf[ErrorInfo](
-      oneOfMapping(StatusCode.NotFound, jsonBody[NotFound]),
-      oneOfMapping(StatusCode.Unauthorized, jsonBody[Unauthorized]),
-      oneOfMapping(StatusCode.NoContent, emptyOutput.map(_ => NoContent)(_ => ())),
-      oneOfDefaultMapping(jsonBody[Unknown])
+      oneOfVariant(StatusCode.NotFound, jsonBody[NotFound]),
+      oneOfVariant(StatusCode.Unauthorized, jsonBody[Unauthorized]),
+      oneOfVariant(StatusCode.NoContent, emptyOutput.map(_ => NoContent)(_ => ())),
+      oneOfDefaultVariant(jsonBody[Unknown])
     )
 
   val statusCodeGetter: Getter[ErrorInfo, StatusCode] = {

--- a/modules/sttp-tapir/src/test/scala/io/janstenpickle/trace4cats/sttp/tapir/model/ErrorInfoException.scala
+++ b/modules/sttp-tapir/src/test/scala/io/janstenpickle/trace4cats/sttp/tapir/model/ErrorInfoException.scala
@@ -19,10 +19,10 @@ object ErrorInfoException {
 
   val endpointOutput: EndpointOutput[ErrorInfoException] =
     oneOf[ErrorInfoException](
-      oneOfMapping(StatusCode.NotFound, jsonBody[NotFound]),
-      oneOfMapping(StatusCode.Unauthorized, jsonBody[Unauthorized]),
-      oneOfMapping(StatusCode.NoContent, emptyOutput.map(_ => NoContent)(_ => ())),
-      oneOfDefaultMapping(jsonBody[Unknown])
+      oneOfVariant(StatusCode.NotFound, jsonBody[NotFound]),
+      oneOfVariant(StatusCode.Unauthorized, jsonBody[Unauthorized]),
+      oneOfVariant(StatusCode.NoContent, emptyOutput.map(_ => NoContent)(_ => ())),
+      oneOfDefaultVariant(jsonBody[Unknown])
     )
 
   val statusCodeGetter: Getter[ErrorInfoException, StatusCode] = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
     val logback = "1.2.7"
     val sttpClient3 = "3.3.15"
     val sttpModel = "1.4.15"
-    val sttpTapir = "0.19.0-M12"
+    val sttpTapir = "0.19.0-M16"
 
     val kindProjector = "0.13.2"
     val betterMonadicFor = "0.3.1"


### PR DESCRIPTION
Tapir has introduced the idea of an authentication stage, which can extract auth and user contenxt. This caused a change to the signature of a number of types, including `ServerEndpoint`.

This commit tries to provide the least amount of API change, that allows "public" endpoints to be traced. Adding authenticated endpoints requires more decisions, e.g. is there a need for `ResourceKleisli[F, A, Either[E, Ctx]]`? How should the authentication stage be traced, if at all?
